### PR TITLE
Add `userDrawnFeatures()` to retrieve user (non-)related features.

### DIFF
--- a/src/annotationService.ts
+++ b/src/annotationService.ts
@@ -214,6 +214,30 @@ export class AnnotationService
     }
 
     /**
+     * Get all annotated features drawn on a resource by current logged-in SPARC user.
+     *
+     * @param  resourceId  The resource's identifier
+     * @return             A Promise resolving to either a list of annotated
+     *                     features drawn on the resource or a reason why
+     *                     features couldn't be retrieved.
+     */
+    async userDrawnFeatures(resourceId: string, participateStatus: boolean): Promise<MapFeature[]|ErrorResult>
+    //========================================================================================================
+    {
+        const features = await this.#request('features/participation', 'GET', {
+            resource: resourceId,
+            participation: {
+                user: this.#currentUser,
+                status: participateStatus
+            }
+        })
+        if (!('error' in features)) {
+            return Promise.resolve(features)
+        }
+        return Promise.resolve(this.#currentError!)
+    }
+
+    /**
      * Get all annotations about a specific item in a resource.
      *
      * @param  resourceId  The resource's identifier


### PR DESCRIPTION
The `userDrawnFeatures()` will be used to send requests to the new server API, which can be found in the PR [here](https://github.com/AnatomicMaps/flatmap-server/pull/8).

The primary function is to retrieve drawn annotation features a logged-in user participated in or did not. This will provide users convenience and improve interactivity while using the annotation tool in Flatmapvuer.